### PR TITLE
Added support for Building on Windows x86_64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,6 @@ common --experimental_repo_remote_exec
 build --jobs 128
 #build --define='absl=1'  # for gtest
 build --enable_platform_specific_config
-build --force_pic
 build --define darwinn_portable=1
 build --verbose_failures
 build --sandbox_debug

--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ matrix.target }}
           path: |
-            ~/.cache
+            .cache
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -56,7 +56,7 @@ jobs:
             ~/.cargo/git
             target
             rust/Cargo.lock
-            ~/.cache
+            .cache
           key: ${{ runner.os }}-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ example/build/*
 .DS_Store
 target/
 Cargo.lock
+.cache

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ ifeq ($(filter $(COMPILATION_MODE),opt dbg fastbuild),)
 $(error COMPILATION_MODE must be opt, dbg or fastbuild)
 endif
 
+BAZEL := bazel --output_base $(MAKEFILE_DIR)/.cache/bazel
+
 ifeq ($(COMPILATION_MODE), opt)
 BAZEL_BUILD_FLAGS += --linkopt=-Wl,--strip-all
 endif
@@ -47,12 +49,12 @@ runecoral_header: runecoral/runecoral.h
 	install runecoral/runecoral.h $(PREFIX)/dist/include
 
 librunecoral-linux-%: runecoral/runecoral.h runecoral/runecoral.cpp runecoral/private/accelerationbackends.h runecoral/private/utils.h
-	$(DOCKER_RUN) $(DOCKER_IMAGE_LINUX) bazel build -c $(COMPILATION_MODE) $(BAZEL_BUILD_FLAGS) --config=linux_$* //runecoral:runecoral
+	$(DOCKER_RUN) $(DOCKER_IMAGE_LINUX) $(BAZEL) build -c $(COMPILATION_MODE) $(BAZEL_BUILD_FLAGS) --config=linux_$* //runecoral:runecoral
 	mkdir -p $(PREFIX)/dist/lib/linux/$*/
 	install bazel-bin/runecoral/librunecoral.a $(PREFIX)/dist/lib/linux/$*
 
 librunecoral-android-%: runecoral/runecoral.h runecoral/runecoral.cpp runecoral/private/accelerationbackends.h runecoral/private/utils.h
-	$(DOCKER_RUN) $(DOCKER_IMAGE_ANDROID) bazel build -c $(COMPILATION_MODE) $(BAZEL_BUILD_FLAGS) --config=android_$* //runecoral:runecoral
+	$(DOCKER_RUN) $(DOCKER_IMAGE_ANDROID) $(BAZEL) build -c $(COMPILATION_MODE) $(BAZEL_BUILD_FLAGS) --config=android_$* //runecoral:runecoral
 	mkdir -p $(PREFIX)/dist/lib/android/$*/ ;
 	install bazel-bin/runecoral/librunecoral.a $(PREFIX)/dist/lib/android/$*
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ dist: runecoral_header librunecoral-linux librunecoral-android
 
 runecoral_header: runecoral/runecoral.h
 	mkdir -p $(PREFIX)/dist/include
-	install runecoral/runecoral.h $(MAKEFILE_DIR)/dist/include
+	install runecoral/runecoral.h $(PREFIX)/dist/include
 
 librunecoral-linux-%: runecoral/runecoral.h runecoral/runecoral.cpp runecoral/private/accelerationbackends.h runecoral/private/utils.h
 	$(DOCKER_RUN) $(DOCKER_IMAGE_LINUX) bazel build -c $(COMPILATION_MODE) $(BAZEL_BUILD_FLAGS) --config=linux_$* //runecoral:runecoral

--- a/README.md
+++ b/README.md
@@ -6,8 +6,17 @@ A thinly veiled wrapper around tflite and libedgetpu from Google
 ## Building
 
 #### Prerequisites
+
+Linux:
 * docker installation [set up properly](https://docs.docker.com/get-started/)
 * git
+
+Windows 10:
+* Visual Studio Build tools 2019
+* Msys2
+* choco install python llvm bazel
+* pip install numpy
+* rust
 
 #### Getting the sources
 ```bash
@@ -22,10 +31,9 @@ $ make docker-image-linux
 $ docker image ls
 REPOSITORY                      TAG     IMAGE ID       CREATED         SIZE
 docker.pkg.github.com/hotg-ai/librunecoral/runecoral-cross-linux     latest  b431b6fa5895   7 hours ago     2.94GB
-
 ```
 
-### Build the package
+### Build the package for Linux
 ```bash
 $ make librunecoral-linux-aarch64
 $ ls dist/include
@@ -39,6 +47,14 @@ $ ls dist/lib/linux
 arm  arm64  x86_64
 ```
 
+### Build the package for / on Windows
+```
+$ bazel build --config windows //runecoral:runecoral
+$ ls bazel-bin/runecoral/
+_objs  runecoral.lib  runecoral.params
+```
+
 # Thanks to:
 * Webcoral
 * libedgetpu
+* mediapipe

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,13 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
 project(runecoralexample)
 
-set(LIBRUNECORAL_DIR ${CMAKE_SOURCE_DIR}/third_party/librunecoral)
+set(LIBRUNECORAL_DIR ${CMAKE_SOURCE_DIR}/..)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules/" ${CMAKE_MODULE_PATH})
 include(cmake/EmbedResources.cmake)
 
 find_package(Threads REQUIRED)
-find_package(EGL REQUIRED)
-find_package(OpenGLES3 REQUIRED)
+set(ADDITIONAL_LIBRARIES "")
+
+if (NOT WIN32)
+    # TODO: Make sure to build the correct binaries/libraries on windows too
+    find_package(EGL REQUIRED)
+    find_package(OpenGLES3 REQUIRED)
+    list(APPEND ADDITIONAL_LIBRARIES EGL::EGL OpenGLES3::OpenGLES3)
+endif()
 
 if(NOT EXISTS "${CMAKE_BINARY_DIR}/sinemodel.h" OR "sinemodel.tflite" IS_NEWER_THAN "${CMAKE_BINARY_DIR}/sinemodel.h")
     embed_resources("${CMAKE_BINARY_DIR}/sinemodel.h"
@@ -24,13 +30,12 @@ else()
     set(LIBRUNECORAL_LIB_DIR "${LIBRUNECORAL_DIR}/lib/${TARGET_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}/")
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${LIBRUNECORAL_DIR}/include ${CMAKE_BINARY_DIR})
+target_include_directories(${PROJECT_NAME} PRIVATE ${LIBRUNECORAL_DIR}/runecoral ${CMAKE_BINARY_DIR})
+target_link_directories(${PROJECT_NAME} PRIVATE ${LIBRUNECORAL_LIB_DIR})
 target_link_libraries(${PROJECT_NAME} PRIVATE
-                        -L${LIBRUNECORAL_LIB_DIR}
-                        -lrunecoral
+                        runecoral
                         Threads::Threads
                         ${CMAKE_DL_LIBS}
-                        EGL::EGL
-                        OpenGLES3::OpenGLES3)
+                        ${ADDITIONAL_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[]) {
 
     int backends = availableAccelerationBackends();
 
-    std::cout << "Can use Tpu Backend? " << (backends & RuneCoralAccelerationBackend__Libedgetpu ? "yes" : "no") << std::endl;
+    std::cout << "Can use Tpu Backend? " << (backends & RuneCoralAccelerationBackend__Edgetpu ? "yes" : "no") << std::endl;
     std::cout << "Can use Gpu Backend? " << (backends & RuneCoralAccelerationBackend__Gpu ? "yes" : "no") << std::endl;
 
     auto contextCreationResult = create_inference_context(RUNE_CORAL_MIME_TYPE__TFLITE,

--- a/runecoral/cc_static_library.bzl
+++ b/runecoral/cc_static_library.bzl
@@ -7,18 +7,33 @@ def _cc_static_library_impl(ctx):
     for cc_dep in cc_deps:
         for link_input in cc_dep.linking_context.linker_inputs.to_list():
             for library in link_input.libraries:
-                libraries += library.pic_objects
-    args = ["r", ctx.outputs.out.path] + [f.path for f in libraries]
+                libraries += library.objects
 
     cc_toolchain = find_cpp_toolchain(ctx)
-    # TODO: Make sure this call works on Windows environment too
-    ctx.actions.run(
-        inputs = depset(libraries),
-        outputs = [ctx.outputs.out],
-        executable = cc_toolchain.ar_executable,
-        arguments = args,
-    )
-    return [DefaultInfo()]
+    # On Windows: Ugly workaround: https://github.com/bazelbuild/bazel/issues/9209
+    if  ctx.configuration.host_path_separator == ";":
+        params_file = ctx.actions.declare_file(ctx.label.name + ".params")
+        out_file = ctx.actions.declare_file(ctx.label.name + ".lib")
+        ctx.actions.write(output = params_file, content = "\r\n".join([f.path for f in libraries]))
+        args = ["/NOLOGO", "/LTCG", "/MACHINE:X64",
+                    "/OUT:{}".format(out_file.path)] + ["@" + params_file.path]
+        ctx.actions.run(
+            inputs = depset(libraries),
+            outputs = [out_file],
+            executable = cc_toolchain.ar_executable,
+            arguments = args,
+        )
+        return [DefaultInfo(files = depset([params_file, out_file]))]
+    else:
+        out_file = ctx.actions.declare_file("lib" + ctx.label.name + ".a")
+        args = ["r", out_file.path] + [f.path for f in libraries]
+        ctx.actions.run(
+            inputs = depset(libraries),
+            outputs = [out_file],
+            executable = cc_toolchain.ar_executable,
+            arguments = args,
+        )
+        return [DefaultInfo(files = depset([out_file]))]
 
 cc_static_library = rule(
     implementation = _cc_static_library_impl,
@@ -28,6 +43,5 @@ cc_static_library = rule(
         ),
         "deps": attr.label_list(providers = [CcInfo]),
     },
-    fragments = ["cpp"],
-    outputs = {"out": "lib%{name}.a"},
+    fragments = ["cpp"]
 )

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -86,6 +86,9 @@ fn make_librunecoral_windows() {
     fs::create_dir_all(librunecoral_path()).unwrap();
 
     let mut cmd = Command::new("bazel");
+    cmd.arg("--output_base")
+       .arg(project_root().join(".cache").join("bazel"));
+
     cmd.arg("build")
        .arg("--config")
        .arg("windows")

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -58,6 +58,11 @@ fn execute_cmd(mut cmd: Command) {
     }
 }
 
+fn make_runecoral_h() {
+    fs::create_dir_all(runecoral_h_path()).unwrap();
+    fs::copy(project_root().join("runecoral").join("runecoral.h"), runecoral_h_path().join("runecoral.h")).ok();
+}
+
 fn make_librunecoral(target_os: &str) {
     // Run the same build command from the README.
     let mut cmd = Command::new("make");
@@ -78,7 +83,6 @@ fn make_librunecoral(target_os: &str) {
 
 fn make_librunecoral_windows() {
     // We are doing the job of make
-    fs::create_dir_all(runecoral_h_path()).unwrap();
     fs::create_dir_all(librunecoral_path()).unwrap();
 
     let mut cmd = Command::new("bazel");
@@ -97,8 +101,6 @@ fn make_librunecoral_windows() {
     cmd.current_dir(project_root());
 
     execute_cmd(cmd);
-
-    fs::copy(project_root().join("runecoral").join("runecoral.h"), runecoral_h_path().join("runecoral.h")).ok();
     fs::copy(project_root().join("bazel-bin").join("runecoral").join("runecoral.lib"), librunecoral_path().join("runecoral.lib")).ok();
 }
 
@@ -112,6 +114,7 @@ fn main() {
         "windows" => make_librunecoral_windows(),
         _ => panic!("Target OS not supported!")
     };
+    make_runecoral_h();
 
     println!("cargo:rustc-link-search={}", project_root().join(librunecoral_path()).display().to_string());
     println!("cargo:rustc-link-lib=runecoral");

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}, process::{Command, Output, Stdio}};
+use std::{fs, path::{Path, PathBuf}, process::{Command, Output, Stdio}};
 
 use bindgen::Builder;
 
@@ -25,30 +25,23 @@ fn librunecoral_path() -> PathBuf  {
         .join(target_arch())
 }
 
-fn make_librunecoral(target_os: &str) {
-    // Run the same build command from the README.
-    let mut cmd = Command::new("make");
+fn runecoral_h_path() -> PathBuf {
+    project_root()
+    .join(std::env::var("OUT_DIR").unwrap())
+    .join("dist")
+    .join("include")
+}
 
-    cmd.current_dir(project_root());
-    cmd.arg(format!("librunecoral-{}-{}", target_os, target_arch()))
-       .arg(format!("PREFIX={}", std::env::var("OUT_DIR").unwrap()));
-
-    if cfg!(feature = "edgetpu_acceleration") {
-        cmd.arg("EDGETPU_ACCELERATION=true");
-    }
-    if cfg!(feature = "gpu_acceleration") {
-        cmd.arg("GPU_ACCELERATION=true");
-    }
-
-    cmd.stdin(Stdio::null())
-       .stdout(Stdio::piped())
-       .stderr(Stdio::piped());
-
+fn execute_cmd(mut cmd: Command) {
     let Output {
         stdout,
         stderr,
         status,
     } = cmd.output().unwrap();
+
+    cmd.stdin(Stdio::null())
+       .stdout(Stdio::piped())
+       .stderr(Stdio::piped());
 
     if !status.success() {
         let stdout = String::from_utf8_lossy(&stdout);
@@ -65,14 +58,58 @@ fn make_librunecoral(target_os: &str) {
     }
 }
 
+fn make_librunecoral(target_os: &str) {
+    // Run the same build command from the README.
+    let mut cmd = Command::new("make");
+
+    cmd.current_dir(project_root());
+    cmd.arg(format!("librunecoral-{}-{}", target_os, target_arch()))
+       .arg(format!("PREFIX={}", std::env::var("OUT_DIR").unwrap()));
+
+    if cfg!(feature = "edgetpu_acceleration") {
+        cmd.arg("EDGETPU_ACCELERATION=true");
+    }
+    if cfg!(feature = "gpu_acceleration") {
+        cmd.arg("GPU_ACCELERATION=true");
+    }
+
+    execute_cmd(cmd)
+}
+
+fn make_librunecoral_windows() {
+    // We are doing the job of make
+    fs::create_dir_all(runecoral_h_path()).unwrap();
+    fs::create_dir_all(librunecoral_path()).unwrap();
+
+    let mut cmd = Command::new("bazel");
+    cmd.arg("build")
+       .arg("--config")
+       .arg("windows")
+       .arg("//runecoral:runecoral");
+
+    if cfg!(feature = "edgetpu_acceleration") {
+        cmd.arg("--define edgetpu_acceleration=true");
+    }
+    if cfg!(feature = "gpu_acceleration") {
+        cmd.arg("--define gpu_acceleration=true");
+    }
+
+    cmd.current_dir(project_root());
+
+    execute_cmd(cmd);
+
+    fs::copy(project_root().join("runecoral").join("runecoral.h"), runecoral_h_path().join("runecoral.h")).ok();
+    fs::copy(project_root().join("bazel-bin").join("runecoral").join("runecoral.lib"), librunecoral_path().join("runecoral.lib")).ok();
+}
+
 fn main() {
-    let manifest_dir: PathBuf = std::env::var("CARGO_MANIFEST_DIR").unwrap().into();
-    let header_file = manifest_dir.join("runecoral.h");
+    let header_file = runecoral_h_path().join("runecoral.h");
 
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     match  target_os.as_str() {
         "linux" => make_librunecoral(&target_os),
         "android" => make_librunecoral(&target_os),
+        "windows" => make_librunecoral_windows(),
         _ => panic!("Target OS not supported!")
     };
 
@@ -82,7 +119,10 @@ fn main() {
         println!("cargo:rustc-link-lib=EGL");
         println!("cargo:rustc-link-lib=GLESv2");
     }
-    println!("cargo:rustc-flags=-l dylib=stdc++");
+
+    if target_os.as_str() == "linux" {
+        println!("cargo:rustc-flags=-l dylib=stdc++");
+    }
 
     let bindings = Builder::default()
         .header(header_file.display().to_string())

--- a/rust/runecoral.h
+++ b/rust/runecoral.h
@@ -1,1 +1,0 @@
-../runecoral/runecoral.h

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -76,7 +76,7 @@ impl InferenceContext {
                 inputs.len() as ffi::size_t,
                 outputs.as_ptr(),
                 outputs.len() as ffi::size_t,
-                acceleration_backend.bits(),
+                acceleration_backend.bits() as i32,
                 inference_context.as_mut_ptr(),
             );
 
@@ -194,9 +194,9 @@ pub enum InferError {
 
 bitflags! {
     pub struct AccelerationBackend: u32 {
-        const NONE = ffi::RuneCoralAccelerationBackend__None;
-        const EDGETPU = ffi::RuneCoralAccelerationBackend__Edgetpu;
-        const GPU = ffi::RuneCoralAccelerationBackend__Gpu;
+        const NONE = ffi::RuneCoralAccelerationBackend__None as u32;
+        const EDGETPU = ffi::RuneCoralAccelerationBackend__Edgetpu as u32;
+        const GPU = ffi::RuneCoralAccelerationBackend__Gpu as u32;
     }
 }
 

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -1,5 +1,6 @@
 use crate::{ffi, Error, Tensor, TensorMut, TensorDescriptor};
 use std::{
+    convert::TryInto,
     ffi::{CString},
     mem::MaybeUninit,
     fmt::{self, Debug, Formatter},
@@ -76,7 +77,7 @@ impl InferenceContext {
                 inputs.len() as ffi::size_t,
                 outputs.as_ptr(),
                 outputs.len() as ffi::size_t,
-                acceleration_backend.bits() as i32,
+                (acceleration_backend.bits() as i32).try_into().unwrap(),
                 inference_context.as_mut_ptr(),
             );
 


### PR DESCRIPTION
We can now build librunecoral (runecoral.lib) on Windows

Verified by building on:

Windows 10 with the following dependencies:
Visual Studio
Msys2
choco install python llvm bazel
pip install numpy
rust

TODO: We are unable to set up github actions for this yet, because of a bazel bug that keeps choosing older version of Visual Studio (2014) despite what environment variables I set. So We setup CI for windows later on.