### PR TITLE
Minor fixes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,7 +10,7 @@ build --enable_platform_specific_config
 build --define darwinn_portable=1
 build --verbose_failures
 build --sandbox_debug
-
+build --define=no_tensorflow_py_deps=true
 # Enable stack traces
 test --test_env="GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1"
 
@@ -43,7 +43,6 @@ build:windows --copt=/w
 # For using M_* math constants on Windows with MSVC.
 build:windows --copt=/D_USE_MATH_DEFINES
 build:windows --host_copt=/D_USE_MATH_DEFINES
-build:windows --define=no_tensorflow_py_deps=true
 
 # macOS
 build:macos --cxxopt=-std=c++17

--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,7 @@ build:windows --copt=/w
 # For using M_* math constants on Windows with MSVC.
 build:windows --copt=/D_USE_MATH_DEFINES
 build:windows --host_copt=/D_USE_MATH_DEFINES
+build:windows --define=no_tensorflow_py_deps=true
 
 # macOS
 build:macos --cxxopt=-std=c++17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,7 @@ version = "0.2.1-alpha.0"
 dependencies = [
  "bindgen",
  "bitflags",
+ "itertools",
  "static_assertions",
  "thiserror",
 ]
@@ -162,6 +169,15 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "rust/lib.rs"
 [dependencies]
 bitflags = "1.3.2"
 thiserror = "1.0.29"
+itertools = "0.10.1"
 
 [features]
 edgetpu_acceleration = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://hotg.dev/"
 repository = "https://github.com/hotg-ai/librunecoral"
 categories = ["science", "wasm"]
 keywords = ["rune", "coral", "tensorflow"]
+exclude = ["bazel-bin", "bazel-librunecoral", "bazel-out", "bazel-testlogs"]
 
 [lib]
 path = "rust/lib.rs"

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ BAZEL ?= bazel
 
 ifeq ($(COMPILATION_MODE), opt)
 BAZEL_BUILD_FLAGS += --linkopt=-Wl,--strip-all
+else
+# From tensorflow's bazelrc
+# Workaround for: https://github.com/tensorflow/tensorflow/issues/33360
+BAZEL_BUILD_FLAGS += -c dbg --cxxopt -DTF_LITE_DISABLE_X86_NEON --copt -DDEBUG_BUILD
 endif
 
 EDGETPU_ACCELERATION ?= false

--- a/build.rs
+++ b/build.rs
@@ -161,7 +161,7 @@ fn make_librunecoral_windows() {
     execute_cmd(cmd);
 
     if compilation_mode() == "dbg" {
-        println!("cargo:rustc-link-lib=MSVCRTD")
+        println!("cargo:rustc-link-lib=MSVCRTD");
     }
 
     fs::copy(

--- a/build.rs
+++ b/build.rs
@@ -50,6 +50,13 @@ fn bazel_cache_dir() -> PathBuf {
         .join("bazel-cache")
 }
 
+fn compilation_mode() -> String {
+    String::from(match std::env::var("PROFILE").unwrap().as_str() {
+        "release" => "opt",
+        _ => "dbg"
+    })
+}
+
 fn target_arch() -> String {
     match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_ref() {
         "aarch64" => "arm64".to_string(),
@@ -109,7 +116,8 @@ fn make_librunecoral(target_os: &str) {
 
     cmd.current_dir(project_root());
     cmd.arg(format!("librunecoral-{}-{}", target_os, target_arch()))
-        .arg(format!("PREFIX={}", std::env::var("OUT_DIR").unwrap()));
+        .arg(format!("PREFIX={}", std::env::var("OUT_DIR").unwrap()))
+        .arg(format!("COMPILATION_MODE={}", compilation_mode()));
 
     cmd.arg(format!("BAZEL=bazel --batch --output_base={}", bazel_cache_dir().to_str().unwrap()));
 
@@ -135,6 +143,8 @@ fn make_librunecoral_windows() {
         .arg(bazel_cache_dir());
 
     cmd.arg("build")
+        .arg("-c")
+        .arg(compilation_mode())
         .arg("--config")
         .arg("windows")
         .arg("//runecoral:runecoral");

--- a/build.rs
+++ b/build.rs
@@ -159,6 +159,11 @@ fn make_librunecoral_windows() {
     cmd.current_dir(project_root());
 
     execute_cmd(cmd);
+
+    if compilation_mode() == "dbg" {
+        println!("cargo:rustc-link-lib=MSVCRTD")
+    }
+
     fs::copy(
         project_root()
             .join("bazel-bin")

--- a/runecoral/runecoral.cpp
+++ b/runecoral/runecoral.cpp
@@ -17,6 +17,7 @@ const char* RUNE_CORAL_MIME_TYPE__TFLITE = "application/tflite-model";
 
 RuneCoralTensor to_runecoraltensor(const TfLiteTensor &tfLiteTensor) {
     RuneCoralTensor result;
+    result.name = tfLiteTensor.name;
     result.data = nullptr;
     result.type = static_cast<RuneCoralElementType>(tfLiteTensor.type);
     result.rank = tfLiteTensor.dims->size;

--- a/runecoral/runecoral.cpp
+++ b/runecoral/runecoral.cpp
@@ -100,13 +100,14 @@ RuneCoralLoadResult create_inference_context(const char *mimetype, const void *m
         tflite::InterpreterBuilder(*(context->model), context->resolver)(&(context->interpreter));
 
         if (context->interpreter) {
+            if (!accelerateInterpreter(backend, context)) {
+                LOG_E("Unable to accelerate interpreter");
+            }
+
             if (context->interpreter->AllocateTensors() != kTfLiteOk) {
                 LOG_E("Interpreter unable to allocate tensors");
                 result = RuneCoralLoadResult__InternalError;
             } else {
-                if (!accelerateInterpreter(backend, context)) {
-                    LOG_E("Unable to accelerate interpreter");
-                }
 
                 for (size_t i = 0; i < context->interpreter->inputs().size(); i++) {
                     context->inputs.push_back(to_runecoraltensor(*context->interpreter->input_tensor(i)));

--- a/runecoral/runecoral.h
+++ b/runecoral/runecoral.h
@@ -28,6 +28,8 @@ typedef enum {
 typedef struct {
   // What type of elements does this tensor contain?
   RuneCoralElementType type;
+  // C style string to the tensor's name
+  const char *name;
   // Opaque bytes containing the tensor's data.
   void *data;
   // An array containing the length of each of the tensor's dimensions.

--- a/rust/tensors.rs
+++ b/rust/tensors.rs
@@ -115,7 +115,7 @@ impl<'a> TensorDescriptor<'a> {
         // accidentally outlive the original tensor.
         unsafe {
             TensorDescriptor {
-                name: CStr::from_ptr(tensor.name),
+                name: if tensor.name != std::ptr::null() { CStr::from_ptr(tensor.name) } else { CStr::from_bytes_with_nul(b"\0").unwrap() },
                 element_type: ElementType::from(tensor.type_),
                 shape: Cow::Borrowed(std::slice::from_raw_parts(
                     tensor.shape,

--- a/rust/tensors.rs
+++ b/rust/tensors.rs
@@ -1,10 +1,12 @@
-use std::{borrow::Cow, os::raw::c_int};
+use std::{borrow::Cow, fmt, os::raw::c_int};
+use itertools::Itertools;
 
 use crate::ffi;
 
 /// The shape and element type of a [`Tensor`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct TensorDescriptor<'a> {
+    //TODO: Add name, and quant fields
     pub element_type: ElementType,
     pub shape: Cow<'a, [c_int]>,
 }
@@ -115,6 +117,32 @@ impl<'a> TensorDescriptor<'a> {
                 )),
             }
         }
+    }
+}
+
+impl fmt::Display for TensorDescriptor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Write strictly the first element into the supplied output
+        // stream: `f`. Returns `fmt::Result` which indicates whether the
+        // operation succeeded or failed. Note that `write!` uses syntax which
+        // is very similar to `println!`.
+        let element_kind = String::from(match self.element_type {
+            ElementType::Bool => "b",
+            ElementType::UInt8 => "u8",
+            ElementType::Int8 => "i8",
+            ElementType::Int16 => "i16",
+            ElementType::Int32 => "i32",
+            ElementType::Int64 => "i64",
+            ElementType::Float16 => "f16",
+            ElementType::Float32 => "f32",
+            ElementType::Float64 => "f64",
+            ElementType::Complex64 => "c64",
+            ElementType::Complex128 => "c128",
+            ElementType::String => "string",
+            _ => "?"
+        });
+
+        write!(f, "{}[{}]", element_kind, self.shape.iter().map(|&i| i.to_string()).join(","))
     }
 }
 

--- a/rust/tensors.rs
+++ b/rust/tensors.rs
@@ -153,7 +153,7 @@ impl fmt::Display for TensorDescriptor<'_> {
         write!(f, "{}: {}[{}]",
                 self.name.to_str().unwrap(),
                 self.element_type,
-                self.shape.iter().map(|&i| i.to_string()).join(","))
+                self.shape.iter().join(","))
     }
 }
 

--- a/rust/tensors.rs
+++ b/rust/tensors.rs
@@ -128,7 +128,7 @@ impl<'a> TensorDescriptor<'a> {
 
 impl fmt::Display for ElementType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let element_kind = String::from(match self {
+        let element_kind = match self {
             ElementType::Bool => "b",
             ElementType::UInt8 => "u8",
             ElementType::Int8 => "i8",
@@ -142,9 +142,9 @@ impl fmt::Display for ElementType {
             ElementType::Complex128 => "c128",
             ElementType::String => "string",
             _ => "?"
-        });
+        };
 
-        write!(f, "{}", element_kind)
+        f.write_str(element_kind)
     }
 }
 

--- a/rust/tensors.rs
+++ b/rust/tensors.rs
@@ -126,13 +126,9 @@ impl<'a> TensorDescriptor<'a> {
     }
 }
 
-impl fmt::Display for TensorDescriptor<'_> {
+impl fmt::Display for ElementType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Write strictly the first element into the supplied output
-        // stream: `f`. Returns `fmt::Result` which indicates whether the
-        // operation succeeded or failed. Note that `write!` uses syntax which
-        // is very similar to `println!`.
-        let element_kind = String::from(match self.element_type {
+        let element_kind = String::from(match self {
             ElementType::Bool => "b",
             ElementType::UInt8 => "u8",
             ElementType::Int8 => "i8",
@@ -148,7 +144,16 @@ impl fmt::Display for TensorDescriptor<'_> {
             _ => "?"
         });
 
-        write!(f, "{}: {}[{}]", self.name.to_str().unwrap(), element_kind, self.shape.iter().map(|&i| i.to_string()).join(","))
+        write!(f, "{}", element_kind)
+    }
+}
+
+impl fmt::Display for TensorDescriptor<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}[{}]",
+                self.name.to_str().unwrap(),
+                self.element_type,
+                self.shape.iter().map(|&i| i.to_string()).join(","))
     }
 }
 

--- a/tests/smoke-test.rs
+++ b/tests/smoke-test.rs
@@ -4,6 +4,7 @@ use hotg_runecoral::{
 };
 use std::borrow::Cow;
 use itertools::Itertools;
+use std::ffi::CStr;
 
 #[test]
 fn create_inference_context_with_invalid_model() {
@@ -18,7 +19,15 @@ fn create_inference_context_with_invalid_model() {
 fn create_inference_context() {
     let model = include_bytes!("sinemodel.tflite");
 
-    let descriptors = vec![TensorDescriptor {
+    let input_descriptors = vec![TensorDescriptor {
+        name: CStr::from_bytes_with_nul(b"dense_2_input\0").unwrap(),
+        element_type: ElementType::Float32,
+        shape: Cow::Borrowed(&[1, 1]),
+    }];
+
+    
+    let output_descriptors = vec![TensorDescriptor {
+        name: CStr::from_bytes_with_nul(b"Identity\0").unwrap(),
         element_type: ElementType::Float32,
         shape: Cow::Borrowed(&[1, 1]),
     }];
@@ -26,8 +35,8 @@ fn create_inference_context() {
     let context =
         InferenceContext::create_context(mimetype(), model, AccelerationBackend::NONE).unwrap();
 
-    assert_eq!(context.inputs().collect::<Vec<_>>(), descriptors);
-    assert_eq!(context.outputs().collect::<Vec<_>>(), descriptors);
+    assert_eq!(context.inputs().collect::<Vec<_>>(), input_descriptors);
+    assert_eq!(context.outputs().collect::<Vec<_>>(), output_descriptors);
     assert_eq!(context.opcount(), 3);
 }
 

--- a/tests/smoke-test.rs
+++ b/tests/smoke-test.rs
@@ -3,6 +3,7 @@ use hotg_runecoral::{
     TensorDescriptor, TensorMut,
 };
 use std::borrow::Cow;
+use itertools::Itertools;
 
 #[test]
 fn create_inference_context_with_invalid_model() {
@@ -39,6 +40,10 @@ fn run_inference_using_the_sine_model() {
 
     // Note: If the inference context held a reference to our model, this would
     // trigger a use-after-free.
+
+    println!("Inputs: {}", ctx.inputs().join(", ") );
+    println!("Outputs: {}", ctx.inputs().join(", ") );
+
     model.fill(0xAA);
     drop(model);
 

--- a/tests/smoke-test.rs
+++ b/tests/smoke-test.rs
@@ -3,7 +3,6 @@ use hotg_runecoral::{
     TensorDescriptor, TensorMut,
 };
 use std::borrow::Cow;
-use itertools::Itertools;
 use std::ffi::CStr;
 
 #[test]
@@ -25,7 +24,7 @@ fn create_inference_context() {
         shape: Cow::Borrowed(&[1, 1]),
     }];
 
-    
+
     let output_descriptors = vec![TensorDescriptor {
         name: CStr::from_bytes_with_nul(b"Identity\0").unwrap(),
         element_type: ElementType::Float32,

--- a/tests/smoke-test.rs
+++ b/tests/smoke-test.rs
@@ -49,10 +49,6 @@ fn run_inference_using_the_sine_model() {
 
     // Note: If the inference context held a reference to our model, this would
     // trigger a use-after-free.
-
-    println!("Inputs: {}", ctx.inputs().join(", ") );
-    println!("Outputs: {}", ctx.inputs().join(", ") );
-
     model.fill(0xAA);
     drop(model);
 


### PR DESCRIPTION
Add support for building librunecoral in debug mode when specified by `$PROFILE`
Accelerate Interpreter before Allocating Tensors
TensorDescriptor: Add name field
TensorDescriptor: Implement Display trait for TensorDescriptor and ElementType
Exclude bazel symlinks in Cargo.toml

Fixes https://github.com/hotg-ai/librunecoral/issues/27